### PR TITLE
convert_to_draft is passed in the parameter of the uploadMedia functi…

### DIFF
--- a/osm_fieldwork/OdkCentral.py
+++ b/osm_fieldwork/OdkCentral.py
@@ -456,22 +456,26 @@ class OdkForm(OdkCentral):
         self.media = result.json()
         return self.media
 
+
     def uploadMedia(self,
                     projectId: int,
                     xform: str,
-                    filespec: str
+                    filespec: str,
+                    convert_to_draft: bool = True
                     ):
         """Upload an attachement to the ODK Central server"""
         title = os.path.basename(os.path.splitext(filespec)[0])
         datafile = f"{title}.geojson"
         xid = xform.split('_')[2]
-        url = f"{self.base}projects/{projectId}/forms/{xid}/draft"
-        result = self.session.post(url, auth=self.auth, verify=self.verify)
-        if result.status_code == 200:
-            log.debug(f"Modified {title} to draft")
-        else:
-            status = eval(result._content)
-            log.error(f"Couldn't modify {title} to draft: {status['message']}")
+
+        if convert_to_draft: 
+            url = f"{self.base}projects/{projectId}/forms/{xid}/draft"
+            result = self.session.post(url, auth=self.auth, verify=self.verify)
+            if result.status_code == 200:
+                log.debug(f"Modified {title} to draft")
+            else:
+                status = eval(result._content)
+                log.error(f"Couldn't modify {title} to draft: {status['message']}")
 
         url = f"{self.base}projects/{projectId}/forms/{xid}/draft/attachments/{datafile}"
         headers = {"Content-Type": "*/*"}


### PR DESCRIPTION
In this pull request, convert_to_draft is passed dynamically in the uploadMedia function in the ODKCentral class.
This field is required since we don't need to move the form to draft if we have created the form as a draft initially.

If I want to update the form already created, I will want to update the form by updating the xml by creating a form as a draft, and then upload media and publish it.