### PR TITLE
fix: no of threads missing some data at the end

### DIFF
--- a/osm_fieldwork/OdkCentral.py
+++ b/osm_fieldwork/OdkCentral.py
@@ -301,6 +301,7 @@ class OdkProject(OdkCentral):
         self.forms = result.json()
         return self.forms
 
+
     def getAllSubmissions(self,
                         project_id: int,
                         ):
@@ -308,8 +309,9 @@ class OdkProject(OdkCentral):
         timer = Timer(text="getAllSubmissions() took {seconds:.0f}s")
         timer.start()
         xforms = self.listForms(project_id)
-        chunk = round(len(xforms) / self.cores) if round(len(xforms) / self.cores) > 0 else 1
-        cycle = range(0, len(xforms), chunk)
+        chunk = round(len(xforms) / self.cores) if round(len(xforms) / self.cores) > 0 else 1        
+        last_slice = len(xforms) if len(xforms) % chunk == 0 else len(xforms) - 1
+        cycle = range(0, last_slice + chunk, chunk)
         future = None
         result = None
         previous = 0
@@ -336,6 +338,7 @@ class OdkProject(OdkCentral):
                     newdata += data
         timer.stop()
         return newdata
+
 
     def listAppUsers(self,
                      projectId: int

--- a/osm_fieldwork/osmfile.py
+++ b/osm_fieldwork/osmfile.py
@@ -292,6 +292,11 @@ class OsmFile(object):
                 logging.warning("No data in this instance")
                 return False
             field = doc["osm"]
+
+            if "node" not in field:
+                logging.warning("No nodes in this instance")
+                return False
+
         if type(field["node"]) == dict:
             attrs = dict()
             tags = dict()

--- a/osm_fieldwork/osmfile.py
+++ b/osm_fieldwork/osmfile.py
@@ -299,8 +299,12 @@ class OsmFile(object):
                 if k[0] == '@':
                     attrs[k[1:]] = v
                 else:
-                    for pair in field["node"]['tag']:
-                        tags[pair['@k']] = pair['@v']
+                    if type(field["node"]['tag']) == dict:
+                        tags[field["node"]['tag']["@k"]] = field["node"]['tag']["@v"].strip()
+                    else:
+                        for pair in field['node']['tag']:
+                            tags[pair['@k']] = pair['@v']
+
             node = {"attrs": attrs, "tags": tags}
             self.data[node["attrs"]["id"]] = node
         else:


### PR DESCRIPTION
 The range function is used to create a sequence of indices to slice the xforms list. However, it is possible that the last slice does not cover the remaining elements if the length of xforms is not evenly divisible by chunk. In such a case, the last slice may miss some elements, and those submissions will not be downloaded. 
 To fix this bug, I have made sure that the last slice includes all the remaining elements, even if it's not of size chunk. 