### PR TITLE
Add python-levenshtein to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "shapely>=1.8.5",
     "overpy>=0.6",
     "thefuzz>=0.19.0",
+    "levenshtein>=0.21.1",
     "haversine>=2.8.0",
     "flatdict>=4.0.1",
     "ogr>=0.44.0",


### PR DESCRIPTION
Currently we get warnings in FMTM that actually break tests:

```python
../home/appuser/.local/lib/python3.10/site-packages/thefuzz/fuzz.py:11
  /home/appuser/.local/lib/python3.10/site-packages/thefuzz/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
    warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')
```

I installed `levenshtein` to fix this, as we don't really want to force suppress warnings in pytest.

I assume this could actually make `thefuzz` faster too.