### PR TITLE
Remove all refs to OGR, use shapely

### DIFF
--- a/docs/about/basemapper.md
+++ b/docs/about/basemapper.md
@@ -87,15 +87,18 @@ The basic syntax is as follows:
 - -input_file, --This is a required positional argument that specifies the path to the input ODK form.
 - -h, --help show this help message and exit
 - -v, --verbose verbose output
-- -b BOUNDARY, --boundary BOUNDARY - The boundary for the area you want
+- -b BOUNDARY, --boundary BOUNDARY - The boundary for the area you want, as BBOX string or geojson file.
 - -z ZOOMS, --zooms ZOOMS - The Zoom levels
 - -o OUTFILE, --outfile - OUTFILE Output file name
 - -d OUTDIR, --outdir OUTDIR -Output directory name for tile cache
 - -s {ersi,bing,topo,google,oam}, --source {ersi,bing,topo,google,oam} - Imagery source
 
 The suffix of the output file is either **mbtiles** or **sqlitedb**, which is
-used to select the output format. The boundary file must be in
+used to select the output format. The boundary file, if specified, must be in
 [GeoJson](https://geojson.org/) format.
+If in BBOX string format, it must be comma separated:
+"minX,minY,maxX,maxY".
+
 
 ## Imagery Sources
 

--- a/osm_fieldwork/make_data_extract.py
+++ b/osm_fieldwork/make_data_extract.py
@@ -588,33 +588,35 @@ class FileClient(object):
         self.infile = infile
 
     def getFeatures(self,
-                    boundary: str,
                     infile: str,
                     outfile: str,
+                    boundary: str = None,
                     ):
         """
         Extract features from a disk file
 
         Args:
-            boundary (str): The filespec for the project AOI in GeoJson format
             infile (str): A GeoJson file of existing data
             outfile (str): An optional GeoJson output file
+            boundary (str): The filespec for the project AOI in GeoJson format
 
         Returns:
             (FeatureCollection): The features returned from the query
         """
-        log.info("Extracting buildings from %s..." % infile)
+        # TODO untested
+
+        log.info(f"Extracting buildings from {infile}")
+        with open(infile, "r") as f:
+            geojson = json.load(f)
+        geometry = shape(geojson)
+
         if boundary:
-            poly = ogr.Open(boundary)
-            layer = poly.GetLayer()
-            ogr.Layer.Clip(osm, layer, memlayer)
-        else:
-            layer = poly.GetLayer()
+            # TODO layer clipping
+            pass
 
-        tmp = ogr.Open(infile)
-        layer = tmp.GetLayer()
+        # layer.SetAttributeFilter("tags->>'building' IS NOT NULL")
 
-        layer.SetAttributeFilter("tags->>'building' IS NOT NULL")
+        # TODO output file
 
 
 def main():


### PR DESCRIPTION
Fixes #148

- Final bits of code that needed refactoring to use shapely instead of OGR.
- osm-fieldwork no longer requires libgdal, so we could possibly remove it from FMTM too.
- I also updated basemapper.py to accept a bbox string (in addition to geojson file).