### PR TITLE
Fixes

### DIFF
--- a/osm_fieldwork/json2osm.py
+++ b/osm_fieldwork/json2osm.py
@@ -257,6 +257,9 @@ class JsonDump(Convert):
                         lon = v[0]
                         tags['geometry'] = f"{lat} {lon}"
                     continue
+                if key == "xlocation":
+                    tags["geometry"] = v
+                    continue
                 tags[key] = v
             total.append(tags)
         return total


### PR DESCRIPTION
Current version of conflation, passes the geopoint in the osm xml file.
With this change, if there is xlocation in the submission, coordinates are taken from xlocation to the xml file.

