### PR TITLE
Fix basemapper.py threading, add wrapper func, add PMTile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ NEWS
 *.html
 *.mbtiles
 *.sqlitedb
+*.pmtiles
+*tiles/
 
 # Prerequisites
 *.d

--- a/docs/about/basemapper.md
+++ b/docs/about/basemapper.md
@@ -84,7 +84,6 @@ many large areas of Nepal, Turkey, Kenya, Uganda, and Tanzania.
 
 The basic syntax is as follows:
 
-- -input_file, --This is a required positional argument that specifies the path to the input ODK form.
 - -h, --help show this help message and exit
 - -v, --verbose verbose output
 - -b BOUNDARY, --boundary BOUNDARY - The boundary for the area you want, as BBOX string or geojson file.
@@ -107,7 +106,7 @@ If in BBOX string format, it must be comma separated:
 - OAM - OpenAerialMap
 
 The default output directory is **/var/www/html**. The actual
-subdirectory is the soiurce name with **tiles** appended, so for
+subdirectory is the source name with **tiles** appended, so for
 example **/var/www/html/oamtiles**. Putting the map tiles into webroot
 lets JOSM or QGIS use them when working offline.
 

--- a/docs/about/make_data_extract.md
+++ b/docs/about/make_data_extract.md
@@ -24,13 +24,13 @@ ways, but needed to be automated to be used for FMTM.
 
 ## Examples
 
-Make\*data*extract uses a Postgres database to extract OSM data. By
+Make\*data\*extract uses a Postgres database to extract OSM data. By
 default, the program uses **localhost** as the database host. If you
 use \**underpass*as the data base name, this will remotely access the
 [Humanitarian OpenStreetMap Team(HOT)](https://www.hotosm.org)
 maintained OSM database that covers the entire planet, and is updated
 every minute. The name of the database can be specified using the
-*--uri\*\* option. The program extracts the buildings category of OSM
+\*--uri\*\* option. The program extracts the buildings category of OSM
 data by default. The size of the extracted data can be limited using
 the \_--boundary\* option. The program outputs the data in GeoJSON
 format.

--- a/docs/api/basemapper.md
+++ b/docs/api/basemapper.md
@@ -9,3 +9,18 @@ heading_level: 3
 options:
 show_source: false
 heading_level: 3
+
+::: osm_fieldwork.basemapper.create_basemap_file
+options:
+show_source: false
+heading_level: 3
+
+::: osm_fieldwork.basemapper.tile_dir_to_pmtiles
+options:
+show_source: false
+heading_level: 3
+
+::: osm_fieldwork.basemapper.tileid_from_y_tile
+options:
+show_source: false
+heading_level: 3

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -196,14 +196,18 @@ class BaseMapper(object):
             dlthread(self.base, mirrors, self.tiles, self.xy)
         else:
             with concurrent.futures.ThreadPoolExecutor(max_workers=cores) as executor:
+                # results = []
                 block = 0
                 while block <= len(self.tiles):
-                    executor.submit(dlthread, self.base, mirrors, self.tiles[block : block + chunk])
+                    executor.submit(dlthread, self.base, mirrors, self.tiles[block : block + chunk], self.xy)
+                    # result = executor.submit(dlthread, self.base, mirrors, self.tiles[block : block + chunk], self.xy)
+                    # results.append(result)
                     log.debug("Dispatching Block %d:%d" % (block, block + chunk))
                     block += chunk
                 executor.shutdown()
             # log.info("Had %r errors downloading %d tiles for data for %r" % (self.errors, len(tiles), Path(self.base).name))
-
+            # for result in results:
+            #     print(result.result())
         return len(self.tiles)
 
     def tileExists(

--- a/osm_fieldwork/sqlite.py
+++ b/osm_fieldwork/sqlite.py
@@ -170,7 +170,7 @@ class DataFile(object):
             self.cursor.execute(f"INSERT INTO metadata (name, value) VALUES('description', '{description}')")
             # self.cursor.execute(f"INSERT INTO metadata (name, value) VALUES('bounds', '{bounds}')")
             self.cursor.execute("INSERT INTO metadata (name, value) VALUES('format', 'jpg')")
-        elif suffix == ".sqlitedb":
+        if "sqlite" in suffix:
             # s is always 0
             self.cursor.execute("CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s));")
             self.cursor.execute("CREATE INDEX IND on tiles (x,y,z,s)")
@@ -212,8 +212,10 @@ class DataFile(object):
             logging.error("Map tile has no image data!")
             # tile.dump()
             return False
+
         suffix = os.path.splitext(self.dbname)[1]
-        if suffix == ".sqlitedb":
+
+        if "sqlite" in suffix:
             # Osmand tops out at zoom level 16, so the real zoom level is inverse,
             # and can go negative for really high zoom levels.
             z = 17 - tile.z
@@ -221,7 +223,8 @@ class DataFile(object):
                 "INSERT INTO tiles (x, y, z, s, image) VALUES (?, ?, ?, ?, ?)",
                 [tile.x, tile.y, z, 0, sqlite3.Binary(tile.blob)],
             )
-        elif suffix == ".mbtiles":
+
+        if suffix == ".mbtiles":
             y = (1 << tile.z) - tile.y - 1
             self.db.execute(
                 "INSERT INTO tiles (tile_row, tile_column, zoom_level, tile_data) VALUES (?, ?, ?, ?)",

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "docs", "debug", "test", "dev"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:404b2340c4cfb5e12337764d8ed9bd8a138c694f233f30919b990fa265100851"
+content_hash = "sha256:f090277a98b9db75be45327e77567053ef76d56c67acb97680dcf306520bc21e"
 
 [[package]]
 name = "appnope"
@@ -962,6 +962,15 @@ summary = "plugin and hook calling mechanisms for python"
 files = [
     {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
     {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[[package]]
+name = "pmtiles"
+version = "3.2.0"
+summary = "Library and utilities to write and read PMTiles files - cloud-optimized archives of map tiles."
+files = [
+    {file = "pmtiles-3.2.0-py3-none-any.whl", hash = "sha256:f44e85c6622249e99044db7de77e81afa79f12faf3b53f6e0dab7a345f597e8a"},
+    {file = "pmtiles-3.2.0.tar.gz", hash = "sha256:49b24af5ba59c505bd70e8459b5eec889c1213cd7fd39eb6132a516eb8dd4301"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "py-cpuinfo>=9.0.0",
     "requests>=2.31.0",
     "osm-rawdata>=0.1.3",
+    "pmtiles>=3.2.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
#201 is still an enimga 😅 
This PR fixes a small bug with dlthread, not passing the xy param.

1. Fix basemapper dlthread✅
2. Wrap basemapper.py functionality in a helper `create_basemap_file()` function (handling download and mbtile generation together - i.e. the content that was once in `main()`)✅
3. Add PMTile support if the user specifies outfile="xxx.pmtile" ✅

This PR also allows for more flexible specification of sqlite format: `.sqlite`, `.sqlitedb`, `.sqlite3` etc (anything with sqlite in the extension)