### PR TITLE
Revert "[pre-commit.ci] pre-commit autoupdate"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,35 @@
 repos:
   # Versioning: Commit messages & changelog
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.13.0
+    rev: 3.12.0
     hooks:
       - id: commitizen
         stages: [commit-msg]
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 23.11.0
     hooks:
       - id: black
 
   # Lint / autoformat: Python code
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.9"
+    rev: "v0.1.6"
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   # Autoformat: YAML, JSON, Markdown, etc.
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0
     hooks:
       - id: prettier
         args: [--ignore-unknown, --no-error-on-unmatched-pattern, "!chart/**"]
 
   # Lint: Markdown
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.37.0
     hooks:
       - id: markdownlint
         args: [--fix, --ignore, CHANGELOG.md]


### PR DESCRIPTION
Reverts hotosm/osm-fieldwork#216

We don't want prettier alpha versions for now.