### PR TITLE
refactor: return full submissions detail

### DIFF
--- a/osm_fieldwork/OdkCentral.py
+++ b/osm_fieldwork/OdkCentral.py
@@ -651,7 +651,7 @@ class OdkForm(OdkCentral):
         result = self.session.get(url, auth=self.auth, params=filters, verify=self.verify)
         if result.ok:
             self.submissions = result.json()
-            return self.submissions["value"]
+            return self.submissions
         else:
             return list()
 

--- a/osm_fieldwork/OdkCentral.py
+++ b/osm_fieldwork/OdkCentral.py
@@ -961,13 +961,8 @@ class OdkForm(OdkCentral):
             log.info(f"Published {xform} on Central.")
         return result.status_code
 
-
-    def form_fields(self,
-                    projectId:int,
-                    xform:str):
-
-        """
-        Retrieves the form fields for a xform from odk central.
+    def form_fields(self, projectId: int, xform: str):
+        """Retrieves the form fields for a xform from odk central.
 
         Args:
             projectId (int): The ID of the project on ODK Central
@@ -977,16 +972,14 @@ class OdkForm(OdkCentral):
             dict: A json object containing the form fields.
 
         """
-
         if xform.find("_") > 0:
-            xid = xform.split('_')[2]
+            xid = xform.split("_")[2]
         else:
             xid = xform
 
         url = f"{self.base}projects/{projectId}/forms/{xid}/fields?odata=true"
-        result=self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth)
         return result.json()
-
 
     def dump(self):
         """Dump internal data structures, for debugging purposes only."""

--- a/osm_fieldwork/filter_data.py
+++ b/osm_fieldwork/filter_data.py
@@ -196,7 +196,7 @@ class FilterData(object):
                             continue
                         log.warning(f"Tag {key} not in the data model!")
                         continue
-            if 'title' not in properties:
+            if "title" not in properties:
                 properties["label"] = properties["id"]
                 properties["title"] = properties["id"]
             newfeature = Feature(geometry=feature["geometry"], properties=properties)


### PR DESCRIPTION
## Updates
Updated `listSubmission` to return full submissions detail not just value in order to use `@odata.count` which is total submission count that can be useful for the pagination.