### PR TITLE
feat: Add support for BytesIO input in boundary processing

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -26,9 +26,9 @@ import queue
 import re
 import sys
 import threading
+from io import BytesIO
 from pathlib import Path
 from typing import Union
-from io import BytesIO
 
 import geojson
 import mercantile
@@ -127,7 +127,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: Union[str, BytesIO], # Updated type hint to accept BytesIO
+        boundary: Union[str, BytesIO],  # Updated type hint to accept BytesIO
         base: str,
         source: str,
         xy: bool,
@@ -135,7 +135,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (Union[str, BytesIO]): The boundary for the area you want. 
+            boundary (Union[str, BytesIO]): The boundary for the area you want.
                 Can be a BBOX string, or GeoJSON file of the AOI or BytesIO object containing GeoJSON data.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
@@ -275,7 +275,7 @@ class BaseMapper(object):
 
     def makeBbox(
         self,
-        boundary: Union[str, BytesIO], 
+        boundary: Union[str, BytesIO],
     ) -> tuple[float, float, float, float]:
         """Make a bounding box from a shapely geometry.
 
@@ -321,19 +321,18 @@ class BaseMapper(object):
             # Process BytesIO object
             try:
                 boundary.seek(0)
-                geojson_data = boundary.read().decode('utf-8')
+                geojson_data = boundary.read().decode("utf-8")
                 poly = geojson.loads(geojson_data)
                 return self.extract_bbox(poly)
             except Exception as e:
                 log.error(e)
                 raise ValueError("Failed to decode GeoJSON data from BytesIO object") from e
         else:
-            raise ValueError(f"Invalid boundary type: {type(boundary)}. It must be a BBOX string or (.json, .geojson) flie or BytesIO object")
+            raise ValueError(
+                f"Invalid boundary type: {type(boundary)}. It must be a BBOX string or (.json, .geojson) flie or BytesIO object"
+            )
 
-
-    def extract_bbox(
-        self, poly: Union[BaseGeometry, None]
-    ) -> tuple[float, float, float, float]:
+    def extract_bbox(self, poly: Union[BaseGeometry, None]) -> tuple[float, float, float, float]:
         """Extract bounding box from GeoJSON polygon."""
         if "features" in poly:
             geometry = shape(poly["features"][0]["geometry"])
@@ -355,7 +354,7 @@ class BaseMapper(object):
         bbox = geometry.bounds
         # left, bottom, right, top
         # minX, minY, maxX, maxY
-        return bbox 
+        return bbox
 
 
 def tileid_from_y_tile(filepath: Union[Path | str]):
@@ -448,7 +447,7 @@ def create_basemap_file(
 
     Args:
         verbose (bool, optional): Enable verbose output if True.
-        boundary (Union[str, BytesIO], optional): The boundary for the area you want. 
+        boundary (Union[str, BytesIO], optional): The boundary for the area you want.
         tms (str, optional): Custom TMS URL.
         xy (bool, optional): Swap the X & Y coordinates when using a
             custom TMS if True.

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,15 @@
+from io import BytesIO
+from osm_fieldwork.basemapper import create_basemap_file
+
+with open("D:\\customers\\osm-fieldwork\\tests\\testdata\\Rollinsville.geojson", "rb") as f:
+    boundary = f.read() # Read the file into memory
+    boundary_bytesio = BytesIO(boundary)   # Convert the file into a BytesIO object
+
+
+create_basemap_file(
+    verbose=True,
+    boundary=boundary_bytesio,
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,9 +1,10 @@
 from io import BytesIO
+
 from osm_fieldwork.basemapper import create_basemap_file
 
 with open("D:\\customers\\osm-fieldwork\\tests\\testdata\\Rollinsville.geojson", "rb") as f:
-    boundary = f.read() # Read the file into memory
-    boundary_bytesio = BytesIO(boundary)   # Convert the file into a BytesIO object
+    boundary = f.read()  # Read the file into memory
+    boundary_bytesio = BytesIO(boundary)  # Convert the file into a BytesIO object
 
 
 create_basemap_file(

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -19,6 +19,7 @@
 #
 """Test functionalty of basemapper.py."""
 
+import io
 import logging
 import os
 import shutil
@@ -66,5 +67,31 @@ def test_create():
     assert hits == 2
 
 
+def test_create_with_byteio():
+    """Test loading with a BytesIO boundary"""
+    hits = 0
+    with open(boundary, "rb") as f:
+        boundary_bytes = io.BytesIO(f.read())
+    basemap = BaseMapper(boundary_bytes, base, "topo", False)
+    tiles = list()
+    for level in [8, 9, 10, 11, 12]:
+        basemap.getTiles(level)
+        tiles += basemap.tiles
+
+    if len(tiles) == 5:
+        hits += 1
+
+    if tiles[0].x == 52 and tiles[1].y == 193 and tiles[2].x == 211:
+        hits += 1
+
+    outf = DataFile(outfile, basemap.getFormat())
+    outf.writeTiles(tiles, base)
+
+    os.remove(outfile)
+    shutil.rmtree(base)
+
+    assert hits == 2    
+
 if __name__ == "__main__":
     test_create()
+    test_create_with_byteio()

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -90,7 +90,8 @@ def test_create_with_byteio():
     os.remove(outfile)
     shutil.rmtree(base)
 
-    assert hits == 2    
+    assert hits == 2
+
 
 if __name__ == "__main__":
     test_create()


### PR DESCRIPTION
### PR Description

This `PR `enhances the boundary processing functionality within the `BaseMapper` class by introducing the extract_bbox() method. This method facilitates the extraction of bounding boxes from both file inputs (JSON or GeoJSON) and `BytesIO` objects.. Additionally, the `makeBbox()` method has been `refactored` to compute bounding boxes, enhancing the functionality of boundary extraction. A new unit test, `test_create_with_byteio()`, has been implemented to verify the correctness of boundary processing when provided with BytesIO input. 

### Changes Made
- Added `extract_bbox()` method to `BaseMapper` class to handle boundary processing logic and for code reusability.
- Refactored `makeBbox()` method to compute bounding boxes for boundary extraction.
- Implemented `test_create_with_byteio()` unit test to verify boundary processing with BytesIO input.
- Updated documentation and comments for clarity and accuracy.

### Purpose
The primary purpose of this PR is to enable `BytesIO `input for boundary processing within the [BaseMapper ](url)class and enhance testing capabilities accordingly. By allowing BytesIO input, users can provide boundary data in-memory, increasing flexibility in data handling. Additionally, the inclusion of a dedicated unit test ensures that boundary processing with BytesIO input is validated, contributing to the overall reliability and robustness of the codebase.