### PR TITLE
Outreachy Task 

### DIFF
--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,9 @@
+from osm_fieldwork.basemapper import create_basemap_file
+
+create_basemap_file(
+    verbose=True,
+    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,8 +1,13 @@
+from io import BytesIO
 from osm_fieldwork.basemapper import create_basemap_file
+
+with open("C:\Users\jahna\Downloads\map.geojson", "rb") as geojson_file:
+    boundary = geojson_file.read()
+    boundary_bytesio = BytesIO(boundary)
 
 create_basemap_file(
     verbose=True,
-    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    boundary=boundary_bytesio,
     outfile="outreachy.mbtiles",
     zooms="12-15",
     source="esri",


### PR DESCRIPTION
**PR for outreachy Task**

The support for parsing GeoJSON files on disk has been removed from the BaseMapper class and has been placed inside the `main()` function that is only used when running `basemapper` via the command line. The file is to be read and converted to BytesIO object, before passing through to the `create_basemap_file` function.

Changes 

- `boundry` variable is edited to accept str or BytesIO object as the input.
- `makeBbox` Function has been edited so that it can hadle both str and BytesIO input.
- `main()` function has been edited to support parsing GeoJSON files.
 
Tests 
According to the guidance given in [Basemapper allow for in memory BytesIO GeoJSON for boundary param](https://github.com/hotosm/osm-fieldwork/issues/204) the code was tested on below commands 
- via BBox string `pdm run python osm_fieldwork/basemapper.py -b -4.730494 41.650541 -4.725634 41.652874 -z 12-15 -s esri`
- via geojson file `pdm run python osm_fieldwork/basemapper.py -b yourbbox.geojson -z 12-15 -s esri`
- and via python script.