### PR TITLE
Add support for select_multiple in XLSForms

### DIFF
--- a/osm_fieldwork/CSVDump.py
+++ b/osm_fieldwork/CSVDump.py
@@ -38,7 +38,9 @@ log = logging.getLogger(__name__)
 
 
 class CSVDump(Convert):
-    """A class to parse the CSV files from ODK Central."""
+    """
+    A class to parse the CSV files from ODK Central.
+    """
 
     def __init__(
         self,
@@ -64,7 +66,17 @@ class CSVDump(Convert):
     def lastSaved(
         self,
         keyword: str,
-    ):
+    ) -> str:
+        """
+        Get the last saved value for a question.
+
+        Args:
+            keyword (str): The keyword to search for
+
+        Returns:
+            (str): The last saved value for the question
+
+        """
         if keyword is not None and len(keyword) > 0:
             return self.saved[keyword]
         return None
@@ -73,15 +85,37 @@ class CSVDump(Convert):
         self,
         keyword: str,
         value: str,
-    ):
+    ) -> bool:
+        """
+        Update the last saved value for a question.
+
+        Args:
+            keyword (str): The keyword to search for
+            value (str): The new value
+
+        Returns:
+            (bool): If the new value got saved
+
+        """
         if keyword is not None and value is not None and len(value) > 0:
             self.saved[keyword] = value
+            return True
+        else:
+            return False
 
     def parseXLS(
         self,
         xlsfile: str,
-    ):
-        """Parse the source XLSFile if available to look for details we need."""
+    ) -> bool:
+        """
+        Parse the source XLSFile if available to look for details we need.
+
+        Args:
+            xlsfile (str):
+
+        Returns:
+            (bool): whether the file was parsed without error
+        """
         if xlsfile is not None and len(xlsfile) > 0:
             self.entries = pd.read_excel(xlsfile, sheet_name=[0])[0]
             # There will only be a single sheet
@@ -112,7 +146,12 @@ class CSVDump(Convert):
         self,
         filespec: str,
     ):
-        """Create an OSM XML output files."""
+        """
+        Create an OSM XML output files.
+
+        Args:
+            filespec (str): The output file name
+        """
         log.debug("Creating OSM XML file: %s" % filespec)
         self.osm = OsmFile(filespec)
         # self.osm.header()
@@ -121,7 +160,12 @@ class CSVDump(Convert):
         self,
         feature: dict,
     ):
-        """Write a feature to an OSM XML output file."""
+        """
+        Write a feature to an OSM XML output file.
+
+        Args:
+            feature (dict): The OSM feature to write to
+        """
         out = ""
         if "id" in feature["tags"]:
             feature["id"] = feature["tags"]["id"]
@@ -140,24 +184,36 @@ class CSVDump(Convert):
 
     def createGeoJson(
         self,
-        file: str = "tmp.geojson",
+        filespec: str = "tmp.geojson",
     ):
-        """Create a GeoJson output file."""
-        log.debug("Creating GeoJson file: %s" % file)
-        self.json = open(file, "w")
+        """
+        Create a GeoJson output file.
+
+        Args:
+            filespec (str): The output file name
+        """
+        log.debug("Creating GeoJson file: %s" % filespec)
+        self.json = open(filespec, "w")
 
     def writeGeoJson(
         self,
         feature: dict,
     ):
-        """Write a feature to a GeoJson output file."""
+        """
+        Write a feature to a GeoJson output file.
+
+        Args:
+            feature (dict): The OSM feature to write to
+        """
         # These get written later when finishing , since we have to create a FeatureCollection
         if "lat" not in feature["attrs"] or "lon" not in feature["attrs"]:
             return None
         self.features.append(feature)
 
     def finishGeoJson(self):
-        """Write the GeoJson FeatureCollection to the output file and close it."""
+        """
+        Write the GeoJson FeatureCollection to the output file and close it.
+        """
         features = list()
         for item in self.features:
             if len(item["attrs"]["lon"]) == 0 or len(item["attrs"]["lat"]) == 0:
@@ -183,6 +239,7 @@ class CSVDump(Convert):
         Args:
             filespec (str): The file to parse.
             data (str): Or the data to parse.
+
         Returns:
             (list): The list of features with tags
         """
@@ -252,7 +309,15 @@ class CSVDump(Convert):
         self,
         line: str,
     ) -> str:
-        """Extract the basename of a path after the last -."""
+        """
+        Extract the basename of a path after the last -.
+
+        Args:
+            line (str): The path from the json file entry
+
+        Returns:
+            (str): The last node of the path
+        """
         tmp = line.split("-")
         if len(tmp) == 0:
             return line
@@ -262,8 +327,16 @@ class CSVDump(Convert):
     def createEntry(
         self,
         entry: dict,
-    ) -> list:
-        """Create the feature data structure."""
+    ) -> dict:
+        """
+        Create the feature data structure.
+
+        Args:
+            entry (dict): The feature data
+
+        Returns:
+            (dict): The OSM data structure for this entry from the json file
+        """
         # print(line)
         feature = dict()
         attrs = dict()
@@ -326,9 +399,8 @@ class CSVDump(Convert):
 
         return feature
 
-
 def main():
-    """ """
+    """Run conversion directly from the terminal."""
     parser = argparse.ArgumentParser(description="convert CSV from ODK Central to OSM XML")
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
     parser.add_argument("-y", "--yaml", help="Alternate YAML file")

--- a/osm_fieldwork/CSVDump.py
+++ b/osm_fieldwork/CSVDump.py
@@ -103,45 +103,6 @@ class CSVDump(Convert):
         else:
             return False
 
-    def parseXLS(
-        self,
-        xlsfile: str,
-    ) -> bool:
-        """
-        Parse the source XLSFile if available to look for details we need.
-
-        Args:
-            xlsfile (str):
-
-        Returns:
-            (bool): whether the file was parsed without error
-        """
-        if xlsfile is not None and len(xlsfile) > 0:
-            self.entries = pd.read_excel(xlsfile, sheet_name=[0])[0]
-            # There will only be a single sheet
-            names = self.entries["name"]
-            defaults = self.entries["default"]
-            i = 0
-            while i < len(self.entries):
-                if type(self.entries['type'][i]) == float:
-                    self.types[self.entries['name'][i]] = None
-                else:
-                    self.types[self.entries['name'][i]] = self.entries['type'][i].split(' ')[0]
-                i += 1
-            total = len(names)
-            i = 0
-            while i < total:
-                entry = defaults[i]
-                if str(entry) != "nan":
-                    pat = re.compile("..last-saved.*")
-                    if pat.match(entry):
-                        name = entry.split("#")[1][:-1]
-                        self.saved[name] = None
-                    else:
-                        self.defaults[names[i]] = entry
-                i += 1
-        return True
-
     def createOSM(
         self,
         filespec: str,

--- a/osm_fieldwork/CSVDump.py
+++ b/osm_fieldwork/CSVDump.py
@@ -22,11 +22,9 @@ import argparse
 import csv
 import logging
 import os
-import re
 import sys
 from datetime import datetime
 
-import pandas as pd
 from geojson import Feature, FeatureCollection, Point, dump
 
 from osm_fieldwork.convert import Convert
@@ -38,9 +36,7 @@ log = logging.getLogger(__name__)
 
 
 class CSVDump(Convert):
-    """
-    A class to parse the CSV files from ODK Central.
-    """
+    """A class to parse the CSV files from ODK Central."""
 
     def __init__(
         self,
@@ -67,8 +63,7 @@ class CSVDump(Convert):
         self,
         keyword: str,
     ) -> str:
-        """
-        Get the last saved value for a question.
+        """Get the last saved value for a question.
 
         Args:
             keyword (str): The keyword to search for
@@ -86,8 +81,7 @@ class CSVDump(Convert):
         keyword: str,
         value: str,
     ) -> bool:
-        """
-        Update the last saved value for a question.
+        """Update the last saved value for a question.
 
         Args:
             keyword (str): The keyword to search for
@@ -107,8 +101,7 @@ class CSVDump(Convert):
         self,
         filespec: str,
     ):
-        """
-        Create an OSM XML output files.
+        """Create an OSM XML output files.
 
         Args:
             filespec (str): The output file name
@@ -121,8 +114,7 @@ class CSVDump(Convert):
         self,
         feature: dict,
     ):
-        """
-        Write a feature to an OSM XML output file.
+        """Write a feature to an OSM XML output file.
 
         Args:
             feature (dict): The OSM feature to write to
@@ -147,8 +139,7 @@ class CSVDump(Convert):
         self,
         filespec: str = "tmp.geojson",
     ):
-        """
-        Create a GeoJson output file.
+        """Create a GeoJson output file.
 
         Args:
             filespec (str): The output file name
@@ -160,8 +151,7 @@ class CSVDump(Convert):
         self,
         feature: dict,
     ):
-        """
-        Write a feature to a GeoJson output file.
+        """Write a feature to a GeoJson output file.
 
         Args:
             feature (dict): The OSM feature to write to
@@ -172,9 +162,7 @@ class CSVDump(Convert):
         self.features.append(feature)
 
     def finishGeoJson(self):
-        """
-        Write the GeoJson FeatureCollection to the output file and close it.
-        """
+        """Write the GeoJson FeatureCollection to the output file and close it."""
         features = list()
         for item in self.features:
             if len(item["attrs"]["lon"]) == 0 or len(item["attrs"]["lat"]) == 0:
@@ -194,8 +182,7 @@ class CSVDump(Convert):
         filespec: str,
         data: str = None,
     ) -> list:
-        """
-        Parse the CSV file from ODK Central and convert it to a data structure.
+        """Parse the CSV file from ODK Central and convert it to a data structure.
 
         Args:
             filespec (str): The file to parse.
@@ -270,8 +257,7 @@ class CSVDump(Convert):
         self,
         line: str,
     ) -> str:
-        """
-        Extract the basename of a path after the last -.
+        """Extract the basename of a path after the last -.
 
         Args:
             line (str): The path from the json file entry
@@ -284,6 +270,7 @@ class CSVDump(Convert):
             return line
         base = tmp[len(tmp) - 1]
         return base
+
 
 def main():
     """Run conversion directly from the terminal."""

--- a/osm_fieldwork/CSVDump.py
+++ b/osm_fieldwork/CSVDump.py
@@ -285,81 +285,6 @@ class CSVDump(Convert):
         base = tmp[len(tmp) - 1]
         return base
 
-    def createEntry(
-        self,
-        entry: dict,
-    ) -> dict:
-        """
-        Create the feature data structure.
-
-        Args:
-            entry (dict): The feature data
-
-        Returns:
-            (dict): The OSM data structure for this entry from the json file
-        """
-        # print(line)
-        feature = dict()
-        attrs = dict()
-        tags = dict()
-        priv = dict()
-        refs = list()
-
-        # log.debug("Creating entry")
-        # First convert the tag to the approved OSM equivalent
-        if "lat" in entry and "lon" in entry:
-            attrs["lat"] = entry["lat"]
-            attrs["lon"] = entry["lon"]
-        for key, value in entry.items():
-            attributes = (
-                "id",
-                "timestamp",
-                "lat",
-                "lon",
-                "uid",
-                "user",
-                "version",
-                "action",
-            )
-
-            # When using existing OSM data, there's a special geometry field.
-            # Otherwise use the GPS coordinates where you are.
-            if key == "geometry" and len(value) > 0:
-                geometry = value.split(" ")
-                if len(geometry) == 4:
-                    attrs["lat"] = geometry[0]
-                    attrs["lon"] = geometry[1]
-                continue
-
-            if 'lat' in attrs and len(attrs["lat"]) == 0:
-                continue
-
-            if key is not None and len(key) > 0 and key in attributes:
-                attrs[key] = value
-                log.debug("Adding attribute %s with value %s" % (key, value))
-                continue
-
-            if value is not None and value != "no" and value != "unknown":
-                if key == "track" or key == "geoline":
-                    # refs.append(tags)
-                    # log.debug("Adding reference %s" % tags)
-                    refs = value.split(";")
-                elif len(value) > 0:
-                    if self.privateData(key):
-                        priv[key] = value
-                    else:
-                        tags[key] = value
-            feature["attrs"] = attrs
-            if len(tags) > 0:
-                logging.debug(f"TAGS: {tags}")
-                feature["tags"] = tags
-            if len(refs) > 1:
-                feature["refs"] = refs
-            if len(priv) > 0:
-                feature["private"] = priv
-
-        return feature
-
 def main():
     """Run conversion directly from the terminal."""
     parser = argparse.ArgumentParser(description="convert CSV from ODK Central to OSM XML")
@@ -383,6 +308,7 @@ def main():
         csvin = CSVDump(args.yaml)
     else:
         csvin = CSVDump()
+
     csvin.parseXLS(args.xlsfile)
     osmoutfile = os.path.basename(args.infile.replace(".csv", ".osm"))
     csvin.createOSM(osmoutfile)

--- a/osm_fieldwork/convert.py
+++ b/osm_fieldwork/convert.py
@@ -71,6 +71,7 @@ class Convert(YamlFile):
         self.defaults = dict()
         self.entries = dict()
         self.types = dict()
+        self.saved = dict()
         for item in self.yaml.yaml["convert"]:
             key = list(item.keys())[0]
             value = item[key]
@@ -413,12 +414,12 @@ class Convert(YamlFile):
                     attrs["lon"] = geometry[1]
                 continue
 
-            if 'lat' in attrs and len(attrs["lat"]) == 0:
-                continue
+            # if 'lat' in attrs and len(attrs["lat"]) == 0:
+            #    continue
 
             if key is not None and len(key) > 0 and key in attributes:
                 attrs[key] = value
-                log.debug("Adding attribute %s with value %s" % (key, value))
+                # log.debug("Adding attribute %s with value %s" % (key, value))
                 continue
 
             if value is not None and value != "no" and value != "unknown":
@@ -426,6 +427,11 @@ class Convert(YamlFile):
                     # refs.append(tags)
                     # log.debug("Adding reference %s" % tags)
                     refs = value.split(";")
+                elif type(value) != str:
+                    if self.privateData(key):
+                        priv[key] = str(value)
+                    else:
+                        tags[key] = str(value)
                 elif len(value) > 0:
                     if self.privateData(key):
                         priv[key] = value

--- a/osm_fieldwork/convert.py
+++ b/osm_fieldwork/convert.py
@@ -20,9 +20,10 @@
 
 import argparse
 import logging
-import sys
-import pandas as pd
 import re
+import sys
+
+import pandas as pd
 
 from osm_fieldwork.xlsforms import xlsforms_path
 from osm_fieldwork.yamlfile import YamlFile
@@ -30,9 +31,9 @@ from osm_fieldwork.yamlfile import YamlFile
 # Instantiate logger
 log = logging.getLogger(__name__)
 
+
 def escape(value: str) -> str:
-    """
-    Escape characters like embedded quotes in text fields.
+    """Escape characters like embedded quotes in text fields.
 
     Args:
         value (str):The string to modify
@@ -44,9 +45,9 @@ def escape(value: str) -> str:
     tmp = value.replace("&", " and ")
     return tmp.replace("'", "&apos;")
 
+
 class Convert(YamlFile):
-    """
-    A class to apply a YAML config file and convert ODK to OSM.
+    """A class to apply a YAML config file and convert ODK to OSM.
 
     Returns:
         (Convert): An instance of this object
@@ -99,8 +100,7 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """
-        Search he private data category for a keyword.
+        """Search he private data category for a keyword.
 
         Args:
             keyword (str): The keyword to search for
@@ -114,8 +114,7 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """
-        Search the convert data category for a keyword.
+        """Search the convert data category for a keyword.
 
         Args:
             keyword (str): The keyword to search for
@@ -129,8 +128,7 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """
-        Search the convert data category for a ketyword.
+        """Search the convert data category for a ketyword.
 
         Args:
             keyword (str): The keyword to search for
@@ -144,8 +142,7 @@ class Convert(YamlFile):
         self,
         value: str,
     ) -> str:
-        """
-        Get the keyword for a value from the yaml file.
+        """Get the keyword for a value from the yaml file.
 
         Args:
             value (str): The value to find the keyword for
@@ -164,8 +161,7 @@ class Convert(YamlFile):
         self,
         keyword: str = None,
     ) -> str:
-        """
-        Get the values for a primary key.
+        """Get the values for a primary key.
 
         Args:
             keyword (str): The keyword to get the value of
@@ -184,8 +180,7 @@ class Convert(YamlFile):
         tag: str,
         value: str,
     ) -> list:
-        """
-        Convert a tag and value from the ODK represention to an OSM one.
+        """Convert a tag and value from the ODK represention to an OSM one.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -237,8 +232,7 @@ class Convert(YamlFile):
         tag: str,
         value: str,
     ) -> list:
-        """
-        Convert a single tag value.
+        """Convert a single tag value.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -281,8 +275,7 @@ class Convert(YamlFile):
         self,
         tag: str,
     ) -> str:
-        """
-        Convert a single tag.
+        """Convert a single tag.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -314,8 +307,7 @@ class Convert(YamlFile):
         self,
         value: str,
     ) -> list:
-        """
-        Convert a multiple tags from a select_multiple question..
+        """Convert a multiple tags from a select_multiple question..
 
         Args:
             value (str): The tags from the ODK XML file
@@ -324,13 +316,13 @@ class Convert(YamlFile):
             (list): The new tags
         """
         tags = list()
-        for tag in value.split(' '):
+        for tag in value.split(" "):
             low = tag.lower()
             if self.convertData(low):
                 newtag = self.convert[low]
                 # tags.append({newtag}: {value})
-                if newtag.find('=') > 0:
-                    tmp = newtag.split('=')
+                if newtag.find("=") > 0:
+                    tmp = newtag.split("=")
                     tags.append({tmp[0]: tmp[1]})
             else:
                 tags.append({low: "yes"})
@@ -349,10 +341,10 @@ class Convert(YamlFile):
             defaults = self.entries["default"]
             i = 0
             while i < len(self.entries):
-                if type(self.entries['type'][i]) == float:
-                    self.types[self.entries['name'][i]] = None
+                if type(self.entries["type"][i]) == float:
+                    self.types[self.entries["name"][i]] = None
                 else:
-                    self.types[self.entries['name'][i]] = self.entries['type'][i].split(' ')[0]
+                    self.types[self.entries["name"][i]] = self.entries["type"][i].split(" ")[0]
                 i += 1
             total = len(names)
             i = 0
@@ -372,8 +364,7 @@ class Convert(YamlFile):
         self,
         entry: dict,
     ) -> dict:
-        """
-        Create the feature data structure.
+        """Create the feature data structure.
 
         Args:
             entry (dict): The feature data
@@ -449,9 +440,7 @@ class Convert(YamlFile):
         return feature
 
     def dump(self):
-        """
-        Dump internal data structures, for debugging purposes only.
-        """
+        """Dump internal data structures, for debugging purposes only."""
         print("YAML file: %s" % self.filespec)
         print("Convert section")
         for key, val in self.convert.items():
@@ -472,9 +461,7 @@ class Convert(YamlFile):
 # this way than using pytest,
 #
 def main():
-    """
-    This main function lets this class be run standalone by a bash script.
-    """
+    """This main function lets this class be run standalone by a bash script."""
     parser = argparse.ArgumentParser(description="Read and parse a YAML file")
 
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
@@ -535,6 +522,7 @@ def main():
     entry = convert.convertEntry("power", "solar")
     for i in entry:
         print("XX: %r" % i)
+
 
 if __name__ == "__main__":
     """This is just a hook so this file can be run standlone during development."""

--- a/osm_fieldwork/convert.py
+++ b/osm_fieldwork/convert.py
@@ -367,6 +367,81 @@ class Convert(YamlFile):
                 i += 1
         return True
 
+    def createEntry(
+        self,
+        entry: dict,
+    ) -> dict:
+        """
+        Create the feature data structure.
+
+        Args:
+            entry (dict): The feature data
+
+        Returns:
+            (dict): The OSM data structure for this entry from the json file
+        """
+        # print(line)
+        feature = dict()
+        attrs = dict()
+        tags = dict()
+        priv = dict()
+        refs = list()
+
+        # log.debug("Creating entry")
+        # First convert the tag to the approved OSM equivalent
+        if "lat" in entry and "lon" in entry:
+            attrs["lat"] = entry["lat"]
+            attrs["lon"] = entry["lon"]
+        for key, value in entry.items():
+            attributes = (
+                "id",
+                "timestamp",
+                "lat",
+                "lon",
+                "uid",
+                "user",
+                "version",
+                "action",
+            )
+
+            # When using existing OSM data, there's a special geometry field.
+            # Otherwise use the GPS coordinates where you are.
+            if key == "geometry" and len(value) > 0:
+                geometry = value.split(" ")
+                if len(geometry) == 4:
+                    attrs["lat"] = geometry[0]
+                    attrs["lon"] = geometry[1]
+                continue
+
+            if 'lat' in attrs and len(attrs["lat"]) == 0:
+                continue
+
+            if key is not None and len(key) > 0 and key in attributes:
+                attrs[key] = value
+                log.debug("Adding attribute %s with value %s" % (key, value))
+                continue
+
+            if value is not None and value != "no" and value != "unknown":
+                if key == "track" or key == "geoline":
+                    # refs.append(tags)
+                    # log.debug("Adding reference %s" % tags)
+                    refs = value.split(";")
+                elif len(value) > 0:
+                    if self.privateData(key):
+                        priv[key] = value
+                    else:
+                        tags[key] = value
+            feature["attrs"] = attrs
+            if len(tags) > 0:
+                # logging.debug(f"TAGS: {tags}")
+                feature["tags"] = tags
+            if len(refs) > 1:
+                feature["refs"] = refs
+            if len(priv) > 0:
+                feature["private"] = priv
+
+        return feature
+
     def dump(self):
         """
         Dump internal data structures, for debugging purposes only.

--- a/osm_fieldwork/convert.py
+++ b/osm_fieldwork/convert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2020, 2021, 2022, 2023 Humanitarian OpenStreetMap Team
+# Copyright (c) 2020, 2021, 2022, 2023, 2024 Humanitarian OpenStreetMap Team
 #
 # This file is part of OSM-Fieldwork.
 #
@@ -28,8 +28,9 @@ from osm_fieldwork.yamlfile import YamlFile
 # Instantiate logger
 log = logging.getLogger(__name__)
 
-def escape(value: str):
-    """Escape characters like embedded quotes in text fields.
+def escape(value: str) -> str:
+    """
+    Escape characters like embedded quotes in text fields.
 
     Args:
         value (str):The string to modify
@@ -41,9 +42,9 @@ def escape(value: str):
     tmp = value.replace("&", " and ")
     return tmp.replace("'", "&apos;")
 
-
 class Convert(YamlFile):
-    """A class to apply a YAML config file and convert ODK to OSM.
+    """
+    A class to apply a YAML config file and convert ODK to OSM.
 
     Returns:
         (Convert): An instance of this object
@@ -92,13 +93,14 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """See is a keyword is in the private data category.
+        """
+        Search he private data category for a keyword.
 
         Args:
             keyword (str): The keyword to search for
 
         Returns:
-            (bool): Check to see if the keyword is in the private data section
+            (bool): =If the keyword is in the private data section
         """
         return keyword.lower() in self.private
 
@@ -106,7 +108,8 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """See is a keyword is in the convert data category.
+        """
+        Search the convert data category for a keyword.
 
         Args:
             keyword (str): The keyword to search for
@@ -120,7 +123,8 @@ class Convert(YamlFile):
         self,
         keyword: str,
     ) -> bool:
-        """See is a keyword is in the convert data category.
+        """
+        Search the convert data category for a ketyword.
 
         Args:
             keyword (str): The keyword to search for
@@ -134,10 +138,12 @@ class Convert(YamlFile):
         self,
         value: str,
     ) -> str:
-        """Get the keyword for a value from the yaml file.
+        """
+        Get the keyword for a value from the yaml file.
 
         Args:
             value (str): The value to find the keyword for
+
         Returns:
             (str): The keyword if found, or None
         """
@@ -152,7 +158,8 @@ class Convert(YamlFile):
         self,
         keyword: str = None,
     ) -> str:
-        """Get the values for a primary key.
+        """
+        Get the values for a primary key.
 
         Args:
             keyword (str): The keyword to get the value of
@@ -171,7 +178,8 @@ class Convert(YamlFile):
         tag: str,
         value: str,
     ) -> list:
-        """Convert a tag and value from the ODK represention to an OSM one.
+        """
+        Convert a tag and value from the ODK represention to an OSM one.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -223,7 +231,8 @@ class Convert(YamlFile):
         tag: str,
         value: str,
     ) -> list:
-        """Convert a single tag value.
+        """
+        Convert a single tag value.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -266,7 +275,8 @@ class Convert(YamlFile):
         self,
         tag: str,
     ) -> str:
-        """Convert a single tag.
+        """
+        Convert a single tag.
 
         Args:
             tag (str): The tag from the ODK XML file
@@ -299,7 +309,7 @@ class Convert(YamlFile):
         value: str,
     ) -> list:
         """
-        Convert a single tag from a select_multiple question..
+        Convert a multiple tags from a select_multiple question..
 
         Args:
             value (str): The tags from the ODK XML file
@@ -322,7 +332,9 @@ class Convert(YamlFile):
         return tags
 
     def dump(self):
-        """Dump internal data structures, for debugging purposes only."""
+        """
+        Dump internal data structures, for debugging purposes only.
+        """
         print("YAML file: %s" % self.filespec)
         print("Convert section")
         for key, val in self.convert.items():
@@ -343,7 +355,9 @@ class Convert(YamlFile):
 # this way than using pytest,
 #
 def main():
-    """This main function lets this class be run standalone by a bash script."""
+    """
+    This main function lets this class be run standalone by a bash script.
+    """
     parser = argparse.ArgumentParser(description="Read and parse a YAML file")
 
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")

--- a/osm_fieldwork/json2osm.py
+++ b/osm_fieldwork/json2osm.py
@@ -23,13 +23,11 @@ import json
 import logging
 
 # import pandas as pd
-import re
 import sys
 from pathlib import Path
 
 import flatdict
 import geojson
-import shapely
 from geojson import Feature, FeatureCollection, Point, dump
 
 from osm_fieldwork.convert import Convert
@@ -45,8 +43,7 @@ class JsonDump(Convert):
         self,
         yaml: str = None,
     ):
-        """
-        A class to convert the JSON file from ODK Central, or the GeoJson
+        """A class to convert the JSON file from ODK Central, or the GeoJson
         file created by the odk2geojson utility.
 
         Args:
@@ -67,8 +64,7 @@ class JsonDump(Convert):
         self,
         filespec: str = "tmp.osm",
     ) -> OsmFile:
-        """
-        Create an OSM XML output files.
+        """Create an OSM XML output files.
 
         Args:
             filespec (str): The filespec for the output OSM XML file
@@ -84,8 +80,7 @@ class JsonDump(Convert):
         self,
         feature: dict,
     ):
-        """
-        Write a feature to an OSM XML output file.
+        """Write a feature to an OSM XML output file.
 
         Args:
             feature (dict): The feature to write to the OSM XML output file
@@ -108,8 +103,7 @@ class JsonDump(Convert):
         self.osm.write(out)
 
     def finishOSM(self):
-        """
-        Write the OSM XML file footer and close it. The destructor in the
+        """Write the OSM XML file footer and close it. The destructor in the
         OsmFile class should do this, but this is the manual way.
         """
         self.osm.footer()
@@ -118,8 +112,7 @@ class JsonDump(Convert):
         self,
         file="tmp.geojson",
     ):
-        """
-        Create a GeoJson output file.
+        """Create a GeoJson output file.
 
         Args:
             file (str): The filespec of the output GeoJson file
@@ -131,8 +124,7 @@ class JsonDump(Convert):
         self,
         feature: dict,
     ):
-        """
-        Write a feature to a GeoJson output file.
+        """Write a feature to a GeoJson output file.
 
         Args:
             feature (dict): The feature to write to the GeoJson output file
@@ -143,9 +135,7 @@ class JsonDump(Convert):
         self.features.append(feature)
 
     def finishGeoJson(self):
-        """
-        Write the GeoJson FeatureCollection to the output file and close it.
-        """
+        """Write the GeoJson FeatureCollection to the output file and close it."""
         features = list()
         for item in self.features:
             # poi = Point()
@@ -163,8 +153,7 @@ class JsonDump(Convert):
         filespec: str = None,
         data: str = None,
     ) -> list:
-        """
-        Parse the JSON file from ODK Central and convert it to a data structure.
+        """Parse the JSON file from ODK Central and convert it to a data structure.
         The input is either a filespec to open, or the data itself.
 
         Args:
@@ -276,6 +265,7 @@ class JsonDump(Convert):
         # log.debug(f"Finished parsing JSON file {filespec}")
         return total
 
+
 # def json2osm(
 #         cmdln: dict,
 # ) -> str:
@@ -331,6 +321,7 @@ class JsonDump(Convert):
 #     log.info(f"Wrote OSM XML file: {osmoutfile}")
 
 #     return osmoutfile
+
 
 def main():
     """Run conversion directly from the terminal."""
@@ -402,6 +393,7 @@ def main():
     jsonin.finishGeoJson()
     log.info("Wrote OSM XML file: %r" % osmoutfile)
     log.info("Wrote GeoJson file: %r" % jsonoutfile)
+
 
 if __name__ == "__main__":
     """This is just a hook so this file can be run standlone during development."""

--- a/osm_fieldwork/osmfile.py
+++ b/osm_fieldwork/osmfile.py
@@ -108,6 +108,7 @@ class OsmFile(object):
             self.file.flush()
             if self.file is False:
                 self.file.close()
+        self.file = None
 
     def write(
         self,

--- a/osm_fieldwork/xforms.yaml
+++ b/osm_fieldwork/xforms.yaml
@@ -12,6 +12,8 @@
 convert:
   - camptype: tourism
   - openfire: leisure=firepit
+  - fire_pit: leisure=firepit
+  - picnic_table: leisure=picnic_table
   - latitude: lat
   - longitude: lon
   - altitude: ele
@@ -20,7 +22,6 @@ convert:
   - submissiondate: timestamp
   - comment: note
   - view: viewpoint
-  - cell: cellular
   - Monday: Mo
   - Tuesday: Tu
   - Wednesday: We
@@ -113,6 +114,8 @@ private:
   - lateral_system
   - access_roof
   - updatedat
+  - cell
+  - cellular
 
 # All of these tags are in the CSV file, and can be ignored
 ignore:
@@ -120,7 +123,6 @@ ignore:
   - __id
   - model
   - type
-  - features
   - accuracy
   - meta
   - __system
@@ -160,8 +162,12 @@ ignore:
   - government_menu
   - note
   - instanceid
+  - begin_group
+  - end_group
+  - image
 
 multiple:
   - healthcare
   - amenity_type
   - specialty
+  - features

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -19,8 +19,8 @@
 #
 
 import argparse
-import os
 import logging
+import os
 import sys
 
 from osm_fieldwork.convert import Convert

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2021, 2022, 2023 Humanitarian OpenStreetMap Team
+# Copyright (c) 2021, 2022, 2023, 2024 Humanitarian OpenStreetMap Team
 #
 # This file is part of Osm-Fieldwork.
 #
@@ -20,9 +20,14 @@
 
 import argparse
 import os
+import logging
+import sys
 
 from osm_fieldwork.convert import Convert
 from osm_fieldwork.xlsforms import xlsforms_path
+
+# Instantiate logger
+log = logging.getLogger(__name__)
 
 # find the path of root tests dir
 rootdir = os.path.dirname(os.path.abspath(__file__))
@@ -74,9 +79,9 @@ def test_sub_value():
 def test_multiple_value():
     """Test tag value conversion."""
     hits = 0
-    # Test a value that gets converted
-    vals = csv.convertValue("amenity", "coffee")
-    if len(vals) == 2 and vals[0]["amenity"] == "cafe" and vals[1]["cuisine"] == "coffee_shop":
+    vals = csv.convertMultiple("picnic_table fire_pit parking")
+    print(vals)
+    if len(vals) > 0 and vals[0]["leisure"] == "picnic_table" and vals[1]["leisure"] == "firepit":
         hits += 1
     assert hits == 1
 
@@ -84,8 +89,18 @@ def test_multiple_value():
 # Run standalone for easier debugging when not under pytest
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Read and convert a JSON file from ODK Central")
+    parser.add_argument("-v", "--verbose", nargs="?", const="0", help="verbose output")
     parser.add_argument("--infile", default=f"{rootdir}/testdata/testcamps.json", help="The JSON input file")
     args = parser.parse_args()
+
+    # if verbose, dump to the terminal
+    if args.verbose is not None:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format=("%(threadName)10s - %(name)s - %(levelname)s - %(message)s"),
+            datefmt="%y-%m-%d %H:%M:%S",
+            stream=sys.stdout,
+        )
 
     test_keywords()
     test_convert_tag()


### PR DESCRIPTION
Currently when converting from a CSV or JSON file from ODK Central, anything that was a select_multiple question had all the answers in a single string, requiring manual editing which is really tedious. This PR adds real support for select_multiple, and can be enhanced to also work with repeats.The big change in this PR is that now the XLSForm used to collect data is parsed to get all the data types right. This works with both the JSON format and the CSV format. 