### PR TITLE
Refactor: check if place holders in custom tms url contains any space within

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -321,6 +321,12 @@ class BaseMapper(object):
             # FIXME handle other formats for custom TMS
             suffix = "jpg"
 
+        pattern = re.compile(r"\{\s*[xyz]+\s*\}")
+        if bool(pattern.search(url)):
+            msg = "Invalid TMS URL format. Please check the URL placeholders{z}{x}{y}."
+            log.error(msg)
+            raise ValueError(msg)
+
         # Replace "{z}/{x}/{y}" with "%s"
         url = re.sub(r"/{[xyz]+\}", "", url)
         url = url + r"/%s"

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -321,14 +321,16 @@ class BaseMapper(object):
             # FIXME handle other formats for custom TMS
             suffix = "jpg"
 
+        # If placeholders present, validate they have no additional spaces
         pattern = re.compile(r"\{\s*[xyz]+\s*\}")
         if bool(pattern.search(url)):
-            msg = "Invalid TMS URL format. Please check the URL placeholders{z}{x}{y}."
+            msg = "Invalid TMS URL format. Please check the URL placeholders {z}/{x}/{y}."
             log.error(msg)
             raise ValueError(msg)
 
-        # Replace "{z}/{x}/{y}" with "%s"
+        # Remove "{z}/{x}/{y}" placeholders if they are present
         url = re.sub(r"/{[xyz]+\}", "", url)
+        # Append "%s" to the end of the URL to later add the tile path
         url = url + r"/%s"
 
         if is_oam:


### PR DESCRIPTION
## Updates:
- used pattern `r"\{\s*[xyz]+\s*\}"` to check if the place holders contains any space within
- returns True if matches which aborts the background task to generate tiles with invalid tms
- if no placeholders in url, the result will be False. So, pattern will search for spaces only if placeholders `{z}/{x}/{y}` are in url.