### PR TITLE
Fix regex pattern to find spaces in placeholders of tms url

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -322,11 +322,12 @@ class BaseMapper(object):
             suffix = "jpg"
 
         # If placeholders present, validate they have no additional spaces
-        pattern = re.compile(r"\{\s*[xyz]+\s*\}")
-        if bool(pattern.search(url)):
-            msg = "Invalid TMS URL format. Please check the URL placeholders {z}/{x}/{y}."
-            log.error(msg)
-            raise ValueError(msg)
+        if "{" in url and "}" in url:
+            pattern = r".*/\{[zxy]\}/\{[zxy]\}/\{[zxy]\}(?:/|/?)"
+            if not bool(re.search(pattern, url)):
+                msg = "Invalid TMS URL format. Please check the URL placeholders {z}/{x}/{y}."
+                log.error(msg)
+                raise ValueError(msg)
 
         # Remove "{z}/{x}/{y}" placeholders if they are present
         url = re.sub(r"/{[xyz]+\}", "", url)


### PR DESCRIPTION
## Updates:
- refactored the regex pattern to search any spaces within placeholders in the tms url.
- only checks for them if they are present in url.
- pattern is `r".*/\{[zxy]\}/\{[zxy]\}/\{[zxy]\}(?:/|/?)"` which ensures placeholders without spaces for all possible combination of them, such as `{z}{x}{y}`, `{x}{y}{z}` etc.