### PR TITLE
Don't add the note about duplication when writing OSM XML

### DIFF
--- a/osm_fieldwork/osmfile.py
+++ b/osm_fieldwork/osmfile.py
@@ -212,8 +212,6 @@ class OsmFile(object):
                     newkey = escape(key)
                     newval = escape(str(value))
                     osm += f"\n    <tag k='{newkey}' v='{newval}'/>"
-            if modified and key != "note":
-                osm += '\n    <tag k="note" v="Do not upload this without validation!"/>'
             osm += "\n"
 
         osm += "  </way>\n"


### PR DESCRIPTION
Currently a note was added when writing the OSM XML file, which later causes issues with conflicts in JOSM. This should really write clean OSM XML, and any notes about the conflation process should be added at a higher level.