### PR TITLE
Fix writing nodes with no tags, ie... what the way references

### DIFF
--- a/osm_fieldwork/osmfile.py
+++ b/osm_fieldwork/osmfile.py
@@ -212,8 +212,9 @@ class OsmFile(object):
                     newkey = escape(key)
                     newval = escape(str(value))
                     osm += f"\n    <tag k='{newkey}' v='{newval}'/>"
+            if modified:
+                osm += '\n    <tag k="note" v="Do not upload this without validation!"/>'
             osm += "\n"
-
         osm += "  </way>\n"
 
         return osm
@@ -300,8 +301,6 @@ class OsmFile(object):
                     newkey = escape(key)
                     newval = escape(str(value))
                     osm += f"\n    <tag k='{newkey}' v='{newval}'/>"
-            if modified and key != "note":
-                osm += '\n    <tag k="note" v="Do not upload this without validation!"/>'
             osm += "\n  </node>\n"
         else:
             osm += "/>"
@@ -401,7 +400,8 @@ class OsmFile(object):
                         tags[tag["@k"]] = tag["@v"].strip()
                         # continue
                     else:
-                        tags[node["tag"]["@k"]] = node["tag"]["@v"].strip()
+                        if len(node["tags"]) > 0:
+                            tags[node["tags"]["@k"]] = node["tags"]["@v"].strip()
                     # continue
             way = {"attrs": attrs, "refs": refs, "tags": tags}
             self.data.append(way)


### PR DESCRIPTION
Currently when parsing an OSM XML file, there was a bug so the nodes with no tags that were referenced by the ways had a typo, so ignored. Now tagless nodes are processed correctly.