### PR TITLE
Remove multiple duplicates in choice sheets

### DIFF
--- a/osm_fieldwork/update_xlsform.py
+++ b/osm_fieldwork/update_xlsform.py
@@ -44,7 +44,7 @@ def merge_dataframes(mandatory_df: pd.DataFrame, user_question_df: pd.DataFrame,
             ],
             ignore_index=True,
         )
-        return merged_df.drop_duplicates(subset=['list_name', NAME_COLUMN], ignore_index=True)
+        return merged_df.drop_duplicates(subset=["list_name", NAME_COLUMN], ignore_index=True)
 
     # Else we are processing the survey sheet, continue
 

--- a/osm_fieldwork/update_xlsform.py
+++ b/osm_fieldwork/update_xlsform.py
@@ -36,7 +36,7 @@ def merge_dataframes(mandatory_df: pd.DataFrame, user_question_df: pd.DataFrame,
 
     # If processing the choices sheet, retain all duplicates
     if "list_name" in user_question_df.columns:
-        return pd.concat(
+        merged_df = pd.concat(
             [
                 mandatory_df,
                 user_question_df,
@@ -44,6 +44,7 @@ def merge_dataframes(mandatory_df: pd.DataFrame, user_question_df: pd.DataFrame,
             ],
             ignore_index=True,
         )
+        return merged_df.drop_duplicates(subset=['list_name', NAME_COLUMN], ignore_index=True)
 
     # Else we are processing the survey sheet, continue
 


### PR DESCRIPTION
## Issue:
- #302 

## Description:
This PR addresses the issue of duplicate combinations of list_name and name fields in the "choices" sheet when allow_choices_duplicates is enabled. It ensures that only unique combinations are retained after the merging process, improving the accuracy of the choices sheet and preventing redundancy.

## Key Changes:
**Duplicate Removal in Choices Sheet:**

Added logic to remove duplicates based on the list_name and name columns when processing the "choices" sheet.
Implemented using the `drop_duplicates(subset=['list_name', 'name'])` method, ensuring the choice lists have unique entries.

**Before the Fix:**
When allow_choices_duplicates was enabled, the "choices" sheet could have multiple duplicate entries for the same list_name and name combination, leading to redundant data in the final output.

**After the Fix:**
The function now ensures that only unique combinations of list_name and name are retained, improving the integrity of the choices data while retaining necessary survey structure.