### PR TITLE
Allow the XLSForm new_feature question geometry type to be configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   #     retries: 3
 
   proxy:
-    image: "docker.io/nginx:1.25.3-bookworm"
+    image: "docker.io/nginx:1.27.0-bookworm"
     depends_on:
       central:
         condition: service_healthy
@@ -68,7 +68,7 @@ services:
     restart: "unless-stopped"
 
   central:
-    image: "ghcr.io/hotosm/fmtm/odkcentral:v2024.1.0"
+    image: "ghcr.io/hotosm/fmtm/odkcentral:v2024.2.1"
     depends_on:
       central-db:
         condition: service_healthy
@@ -98,7 +98,7 @@ services:
     restart: "unless-stopped"
 
   central-db:
-    image: "postgis/postgis:14-3.4-alpine"
+    image: "postgis/postgis:17-3.5-alpine"
     environment:
       - POSTGRES_USER=odk
       - POSTGRES_PASSWORD=odk

--- a/osm_fieldwork/form_components/mandatory_fields.py
+++ b/osm_fieldwork/form_components/mandatory_fields.py
@@ -95,8 +95,8 @@ def get_mandatory_fields(new_geom_type: DbGeomType):
         {
             "type": geom_field,
             "name": "new_feature",
-            "label::english(en)": "Alternatively, take a gps coordinates of a new feature",
-            "label::nepali(ne)": "वैकल्पिक रूपमा, नयाँ सुविधाको GPS निर्देशांक लिनुहोस्।",
+            "label::english(en)": "Please draw a new geometry",
+            "label::nepali(ne)": "कृपया नयाँ ज्यामिति कोर्नुहोस्।",
             "appearance": "placement-map",
             "relevant": "${feature}= ''",
             "required": "yes",


### PR DESCRIPTION
- Adds the param `new_geom_type` to the `append_mandatory_fields` function.
- Accepts: `POINT`, `POLYGON,` `LINESTRING`.
- Configures the `new_feature` question type based on that.

Note we don't actually use the question type in ODK mostly. But this just inform ODK for the geometry type to be stored in the submission.

Also note the tests are all failing currently due to a dockerfile issue, so we can't run the test suite: https://github.com/hotosm/osm-fieldwork/issues/328