### PR TITLE
Add brazilian portguese translation for mandatory fields

### DIFF
--- a/osm_fieldwork/form_components/choice_fields.py
+++ b/osm_fieldwork/form_components/choice_fields.py
@@ -33,8 +33,20 @@ import pandas as pd
 
 # Define the choices sheet
 choices_data = [
-    {"list_name": "yes_no", "name": "yes", "label::english(en)": "Yes", "label::nepali(ne)": "छ"},
-    {"list_name": "yes_no", "name": "no", "label::english(en)": "No", "label::nepali(ne)": "छैन"},
+    {
+        "list_name": "yes_no",
+        "name": "yes",
+        "label::english(en)": "Yes",
+        "label::nepali(ne)": "छ",
+        "label::portuguese(pt-br)": "Sim",
+    },
+    {
+        "list_name": "yes_no",
+        "name": "no",
+        "label::english(en)": "No",
+        "label::nepali(ne)": "छैन",
+        "label::portuguese(pt-br)": "Não",
+    },
 ]
 
 choices_df = pd.DataFrame(choices_data)
@@ -48,6 +60,7 @@ digitisation_choices = [
         "label::swahili(sw)": "Lumped - poligoni moja (zaidi ya jengo moja limewekwa dijiti kuwa moja)",
         "label::french(fr)": "Lumped - un polygone (plus d'un bâtiment numérisé en un seul)",
         "label::spanish(es)": "Agrupado - un polígono (más de un edificio digitalizado como uno)",
+        "label::portuguese(pt-br)": "Agrupado - um polígono (mais de um edifício digitalizado como um só)",
     },
     {
         "list_name": "digitisation_problem",
@@ -57,6 +70,7 @@ digitisation_choices = [
         "label::swahili(sw)": "Mgawanyiko - jengo moja (jengo moja limebadilishwa kuwa zaidi ya poligoni moja)",
         "label::french(fr)": "Fractionnement - un bâtiment (un bâtiment numérisé sous la forme de plusieurs polygones)",
         "label::spanish(es)": "Split - un edificio (un edificio digitalizado como más de un polígono)",
+        "label::portuguese(pt-br)": "Split - um edifício (um edifício digitalizado como mais de um polígono)",
     },
     {
         "list_name": "digitisation_problem",
@@ -66,6 +80,7 @@ digitisation_choices = [
         "label::swahili(sw)": "MENGINEYO",
         "label::french(fr)": "AUTRES",
         "label::spanish(es)": "OTROS",
+        "label::portuguese(pt-br)": "OUTROS",
     },
 ]
 

--- a/osm_fieldwork/form_components/digitisation_fields.py
+++ b/osm_fieldwork/form_components/digitisation_fields.py
@@ -37,6 +37,7 @@ digitisation_fields = [
         "name": "verification",
         "label::english(en)": "Verification",
         "label::nepali(ne)": "प्रमाणीकरण",
+        "label::portuguese(pt-br)": "Verificação",
         "relevant": "(${new_feature} != '') or (${building_exists} = 'yes')",
     },
     {
@@ -44,6 +45,7 @@ digitisation_fields = [
         "name": "digitisation_correct",
         "label::english(en)": "Is the digitized location for this feature correct?",
         "label::nepali(ne)": "के यो डिजिटाइज गरिएको स्थान सही छ?",
+        "label::portuguese(pt-br)": "O local digitalizado para esse recurso está correto?",
         "relevant": "(${new_feature} != '') or (${building_exists} = 'yes')",
         "calculation": "once(if(${new_feature} != '', 'yes', ''))",
         "read_only": "${new_feature} != ''",
@@ -54,6 +56,7 @@ digitisation_fields = [
         "name": "digitisation_problem",
         "label::english(en)": "What is wrong with the digitization?",
         "label::nepali(en)": "डिजिटलाइजेशनमा के गल्ती छ?",
+        "label::portuguese(pt-br)": "O que há de errado com a digitalização?",
         "relevant": "${digitisation_correct}='no'",
     },
     {
@@ -61,6 +64,7 @@ digitisation_fields = [
         "name": "digitisation_problem_other",
         "label::english(en)": "You said “Other.” Please tell us what went wrong with the digitization!",
         "label::nepali(ne)": "तपाईंले 'अरू' भन्नुभयो। डिजिटलाइजेशनमा के गल्ती भयो! कृपया हामीलाई भन्न सक्नुहुन्छ?",
+        "label::portuguese(pt-br)": "Você disse “Outro”. Diga-nos o que deu errado com a digitalização!",
         "relevant": "${digitisation_problem}='other' ",
     },
     {"type": "end group"},
@@ -69,6 +73,7 @@ digitisation_fields = [
         "name": "image",
         "label::english(en)": "Take a Picture",
         "label::nepali(ne)": "तस्विर लिनुहोस्",
+        "label::portuguese(pt-br)": "Tire uma foto",
         "apperance": "minimal",
         "parameters": "max-pixels=1000",
     },
@@ -77,6 +82,7 @@ digitisation_fields = [
         "name": "end_note",
         "label::english(en)": "You can't proceed with data acquisition, if the building doesn't exist.",
         "label::nepali(ne)": "यदि भवन अवस्थित छैन भने, तपाईं डाटा लिन अगाडि बढ्न सक्नुहुन्न।",
+        "label::portuguese(pt-br)": "Não é possível prosseguir com a aquisição de dados se o edifício não existir.",
         "relevant": "${building_exists} = 'no'",
     },
 ]

--- a/osm_fieldwork/form_components/mandatory_fields.py
+++ b/osm_fieldwork/form_components/mandatory_fields.py
@@ -88,6 +88,8 @@ def get_mandatory_fields(new_geom_type: DbGeomType):
                                 by HOT's FMTM to record ${form_category} map features.""",
             "label::nepali(ne)": """स्वागत छ ${username}। ${form_category} नक्सा Data रेकर्ड गर्न HOT को FMTM द्वारा
                                 यो सर्वेक्षण फारम उत्पन्न भएको थियो।""",
+            "label::portuguese(pt-br)": """Bem-vindo ${username}. Este formulário de pesquisa foi gerado
+                                pelo FMTM do HOT para registrar os recursos do mapa ${form_category}.""",
         },
         {"notes": "Fields essential to FMTM"},
         {"type": "start-geopoint", "name": "warmup", "notes": "collects location on form start"},
@@ -97,6 +99,7 @@ def get_mandatory_fields(new_geom_type: DbGeomType):
             "name": "new_feature",
             "label::english(en)": "Please draw a new geometry",
             "label::nepali(ne)": "कृपया नयाँ ज्यामिति कोर्नुहोस्।",
+            "label::portuguese(pt-br)": "Por favor, desenhe uma nova geometria",
             "appearance": "placement-map",
             "relevant": "${feature}= ''",
             "required": "yes",
@@ -153,6 +156,7 @@ def get_mandatory_fields(new_geom_type: DbGeomType):
             "name": "building_exists",
             "label::english(en)": "Does this feature exist?",
             "label::nepali(ne)": "के यो भवन अवस्थित छ?",
+            "label::portuguese(pt-br)": "Esse recurso existe?",
             "relevant": "${feature} != '' ",
         },
         {

--- a/osm_fieldwork/update_xlsform.py
+++ b/osm_fieldwork/update_xlsform.py
@@ -49,6 +49,7 @@ DEFAULT_LANGUAGES = {
     "spanish": "es",
     "swahili": "sw",
     "nepali": "ne",
+    "portuguese": "pt-br",
 }
 
 # def handle_translations(


### PR DESCRIPTION
## Updates:
I have added brazilian portuguese translations for mandatory fields. Added it in default languages as well.

## Issue:
- https://github.com/hotosm/fmtm/issues/2080

## Review:
Need an xlsx form with brazilian portuguese language label @spwoodcock.