### PR TITLE
Remove invalid Accept: "odkcentral" header (triggers ModSec 920600)

### DIFF
--- a/osm_fieldwork/OdkCentral.py
+++ b/osm_fieldwork/OdkCentral.py
@@ -188,8 +188,6 @@ class OdkCentral(object):
             self.user = user
         if not self.passwd:
             self.passwd = passwd
-        # Enable persistent connection, create a cookie for this session
-        self.session.headers.update({"accept": "odkcentral"})
 
         # Get a session token
         try:
@@ -798,7 +796,7 @@ class OdkForm(OdkCentral):
         # log.debug(f'Getting submissions for {projectId}, Form {xform}')
         result = self.session.get(
             url,
-            headers=dict({"Content-Type": "application/json", "accept": "odkcentral"}, **self.session.headers),
+            headers=dict({"Content-Type": "application/json"}, **self.session.headers),
             verify=self.verify,
         )
         if result.status_code == 200:

--- a/osm_fieldwork/OdkCentralAsync.py
+++ b/osm_fieldwork/OdkCentralAsync.py
@@ -87,7 +87,6 @@ class OdkCentral(object):
         # Header enables persistent connection, creates a cookie for this session
         self.session = aiohttp.ClientSession(
             raise_for_status=True,
-            headers={"accept": "odkcentral"},
         )
         await self.authenticate()
         return self


### PR DESCRIPTION
- No idea why this was set.
- The 'Accept' request header should have a valid value like 'application/json', but instead has 'odkcollect'.